### PR TITLE
Exit uncleanly from the grunt process if protractor returns a non-zero exit code

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   },
   "scripts": {
   },
+  "dependencies": {
+    "protractor": "latest",
+    "shelljs": "latest"
+  },
   "devDependencies": {
-      "protractor": "latest",
-    "shelljs": "latest",
     "grunt": "~0.4.1"
   },
   "peerDependencies": {

--- a/tasks/protractor_simple.js
+++ b/tasks/protractor_simple.js
@@ -43,12 +43,15 @@ module.exports = function(grunt) {
         }).forEach(function(filepath) {
                 // Run protractor with each file
                 console.log('Running \'protractor ' + filepath + '\'');
-                shell.exec("protractor " + filepath,
+                var child = shell.exec("protractor " + filepath,
                     {
                         aysnc: false,
                         silent: false
                     }
                 );
+                if ( child.code != 0 ) {
+                    process.exit(1);
+                }
             });
 
         // Print a success message.


### PR DESCRIPTION
I'm running `grunt` in a container that needs to be told whether testing succeeded by returning a proper exit code, so this does that. Also, I threw in a change to `package.json` that was pushed to RubyGems, but not to the GitHub repository.
